### PR TITLE
Remove flags from binutils

### DIFF
--- a/ports/binutils/Pkgfile
+++ b/ports/binutils/Pkgfile
@@ -36,7 +36,6 @@ build = '''
 				--enable-gold \
 				--enable-deterministic-archives \
 				--disable-nls \
-				--disable-gdb \
 				--disable-werror
 
 			make
@@ -61,11 +60,6 @@ build = '''
 		--enable-shared \
 		--enable-deterministic-archives \
 		--with-system-zlib \
-		--disable-gdb \
-		--disable-gdbserver \
-		--disable-libdecnumber \
-		--disable-readline \
-		--disable-sim \
 		--disable-werror \
 		--enable-targets=x86_64-pep,bpf-unknown-none \
 		--enable-nls


### PR DESCRIPTION
These options only make sense when you're using the git version `binutils-gdb` (which is what Arch does) and not a release tarball as the directories you're disabling (not inlcuding) are already omitted in the release tarball you're downloading.